### PR TITLE
Fix current state saving and initial state

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="flutter.moum.headset_connection_event">
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
 </manifest>

--- a/android/src/main/java/flutter/moum/headset_connection_event/HeadsetBroadcastReceiver.java
+++ b/android/src/main/java/flutter/moum/headset_connection_event/HeadsetBroadcastReceiver.java
@@ -19,7 +19,6 @@ public class HeadsetBroadcastReceiver extends BroadcastReceiver {
         switch (intent.getAction()) {
             case Intent.ACTION_HEADSET_PLUG:
                 final int state = intent.getIntExtra("state", -1);
-                HeadsetConnectionEventPlugin.currentState = state;
 
                 switch (state) {
                     case 0:

--- a/android/src/main/java/flutter/moum/headset_connection_event/HeadsetConnectionEventPlugin.java
+++ b/android/src/main/java/flutter/moum/headset_connection_event/HeadsetConnectionEventPlugin.java
@@ -1,8 +1,10 @@
 package flutter.moum.headset_connection_event;
 
 import android.bluetooth.BluetoothAdapter;
+import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.media.AudioManager;
 
 import androidx.annotation.NonNull;
 
@@ -60,6 +62,9 @@ public class HeadsetConnectionEventPlugin implements FlutterPlugin, MethodCallHa
         filter.addAction(BluetoothAdapter.ACTION_CONNECTION_STATE_CHANGED);
         filter.addAction(BluetoothAdapter.ACTION_STATE_CHANGED);
         flutterPluginBinding.getApplicationContext().registerReceiver(hReceiver, filter);
+
+        AudioManager audioManager = (AudioManager)flutterPluginBinding.getApplicationContext().getSystemService(Context.AUDIO_SERVICE);
+        currentState = audioManager.isWiredHeadsetOn() || audioManager.isBluetoothA2dpOn() ? 1 : 0;
     }
 
     @Override

--- a/android/src/main/java/flutter/moum/headset_connection_event/HeadsetConnectionEventPlugin.java
+++ b/android/src/main/java/flutter/moum/headset_connection_event/HeadsetConnectionEventPlugin.java
@@ -28,11 +28,13 @@ public class HeadsetConnectionEventPlugin implements FlutterPlugin, MethodCallHa
     private final HeadsetEventListener headsetEventListener = new HeadsetEventListener() {
         @Override
         public void onHeadsetConnect() {
+            currentState = 1;
             channel.invokeMethod("connect", "true");
         }
 
         @Override
         public void onHeadsetDisconnect() {
+            currentState = 0;
             channel.invokeMethod("disconnect", "true");
         }
 


### PR DESCRIPTION
Fix for bluetooth connections not properly setting the current state and the current state not being set initially when starting the app.