### PR TITLE
fix: Removes Flutter v1 android embedding references #28

### DIFF
--- a/android/src/main/java/flutter/moum/headset_connection_event/HeadsetConnectionEventPlugin.java
+++ b/android/src/main/java/flutter/moum/headset_connection_event/HeadsetConnectionEventPlugin.java
@@ -15,7 +15,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /**
  * HeadsetConnectionEventPlugin

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: headset_connection_event
 description: Flutter Plugin for headset events. Detect headset is plugged and unplugged. Get current headset state.
-version: 4.0.0
+version: 4.0.1
 author: songyiYu<songyi0207@gmail.com>, yenoss<cpg0504@gmail.com>, FlutterMoum Group<fluttermoum@gmail.com>, Blake Helms (helmsb), Rafael Delos Santos (themobilecoder)
 homepage: https://github.com/themobilecoder/headset_connection_event
 


### PR DESCRIPTION
Fixed: https://github.com/themobilecoder/headset_connection_event/issues/28 issue